### PR TITLE
deprecation comments

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -27,6 +27,9 @@ clean-targets:         # directories to be removed by `dbt clean`
 
 models:
   +copy_grants: true
+  +persist_docs:
+    relation: true
+    columns: true
   +on_schema_change: sync_all_columns
 
 tests:

--- a/models/gold/core__fact_msg_attributes.yml
+++ b/models/gold/core__fact_msg_attributes.yml
@@ -12,11 +12,11 @@ models:
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: BLOCKCHAIN
-        description: "{{ doc('blockchain') }}"
+        description: This column is deprecating on 18 January. In this table, always Axelar. Used to join to cross-chain tables. 
         tests: 
           - dbt_expectations.expect_column_to_exist
       - name: CHAIN_ID
-        description: "{{ doc('chain_id') }}"
+        description: This column is deprecating on 18 January. The name and version of the blockchain. 
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: TX_ID

--- a/models/gold/core__fact_msgs.yml
+++ b/models/gold/core__fact_msgs.yml
@@ -12,11 +12,11 @@ models:
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: BLOCKCHAIN
-        description: "{{ doc('blockchain') }}"
+        description: This column is deprecating on 18 January. In this table, always Axelar. Used to join to cross-chain tables. 
         tests: 
           - dbt_expectations.expect_column_to_exist
       - name: CHAIN_ID
-        description: "{{ doc('chain_id') }}"
+        description: This column is deprecating on 18 January. The name and version of the blockchain. 
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: TX_ID

--- a/models/gold/core__fact_transactions.yml
+++ b/models/gold/core__fact_transactions.yml
@@ -16,11 +16,11 @@ models:
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: BLOCKCHAIN
-        description: "{{ doc('blockchain') }}"
+        description: This column is deprecating on 18 January. In this table, always Axelar. Used to join to cross-chain tables. 
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: CHAIN_ID
-        description: "{{ doc('chain_id') }}"
+        description: This column is deprecating on 18 January. The name and version of the blockchain. 
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: TX_ID

--- a/models/gold/core__fact_transfers.yml
+++ b/models/gold/core__fact_transfers.yml
@@ -12,11 +12,11 @@ models:
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: BLOCKCHAIN
-        description: "{{ doc('blockchain') }}"
+        description: This column is deprecating on 18 January. In this table, always Axelar. Used to join to cross-chain tables. 
         tests: 
           - dbt_expectations.expect_column_to_exist
       - name: CHAIN_ID
-        description: "{{ doc('chain_id') }}"
+        description: This column is deprecating on 18 January. The name and version of the blockchain. 
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: TX_ID


### PR DESCRIPTION
Add to blockchain & chain_id columns in transactions, msgs, msg_attributes, and transfers table that the columns will deprecate on Jan. 18. 